### PR TITLE
docs: add CHANGELOG (Keep a Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Initial repository scaffold
+- 12-skill customer discovery library (in progress)
+- CI workflows (lint, link check, SKILL.md validator)
+- Issue and PR templates
+- Branch protection ruleset on `main`
+
+## [0.1.0] - TBD
+
+- First public release.


### PR DESCRIPTION
Adds a CHANGELOG.md following the Keep a Changelog 1.1.0 format and Semantic Versioning.