### PR TITLE
feat(signal-archaeologist): add capture-layer skill

### DIFF
--- a/skills/signal-archaeologist/README.md
+++ b/skills/signal-archaeologist/README.md
@@ -1,0 +1,9 @@
+# signal-archaeologist
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+This is the human-readable companion. For the canonical contract used by agents, refer to `SKILL.md`.
+
+## Examples
+
+- [Basic example](./examples/basic-example.md)

--- a/skills/signal-archaeologist/SKILL.md
+++ b/skills/signal-archaeologist/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: signal-archaeologist
+version: 0.1.0
+description: Mines historical customer artefacts (tickets, calls, NPS) for buried signals with velocity scoring.
+when_to_use:
+  - You have 6+ months of accumulated support, sales, or NPS text data
+  - You need to surface trends that single-quarter analyses miss
+  - You suspect a slow-burning problem is being ignored
+inputs:
+  - name: archive
+    type: file
+    required: true
+    description: Folder of dated text artefacts (one per record, ISO date in filename or header)
+  - name: time_window
+    type: string
+    required: false
+    description: Lookback window (e.g. "12m"). Defaults to all available.
+outputs:
+  - name: signal_timeline
+    type: markdown
+    description: Chronological signal map with frequency, sentiment, and velocity per theme
+  - name: decay_corrected_themes
+    type: json
+    description: Themes ranked by recency-weighted importance (half-life = 90 days)
+tags: [discovery, voc, capture, historical, archaeology]
+maintainer: "@varunk130"
+---
+
+# signal-archaeologist
+
+## Purpose
+
+Most customer signals decay in salience faster than they decay in importance. Quarterly reports surface what is loud now; truly persistent problems get buried. `signal-archaeologist` excavates them.
+
+## Instructions
+
+1. **Index the archive.** For each artefact extract: ISO date, source channel, raw text, customer segment (if present).
+2. **Cluster into candidate themes** using semantic similarity. Aim for 8–20 themes.
+3. **Compute per-theme metrics** for each rolling 30-day window:
+   - frequency (count of mentions)
+   - sentiment (−1 to +1, mean)
+   - velocity (Δ frequency vs. previous window)
+4. **Apply a 90-day exponential decay** to weight recent signals — but flag any theme whose *velocity* is positive across 3+ consecutive windows. These are the "slow burns."
+5. **Produce two artefacts:**
+   - A markdown timeline grouped by theme, with sparkline-style frequency notation.
+   - A JSON ranked list of themes by `decay_weighted_importance × velocity_score`.
+
+## Output format
+
+See [`examples/basic-example.md`](./examples/basic-example.md).
+
+## Limitations
+
+- Requires reasonably consistent text quality across the time window. Highly templated tickets will under-cluster.
+- Sentiment scoring is coarse; do not use as a quantitative SLA metric.
+- Does not deduplicate the same customer raising the same issue across multiple channels.

--- a/skills/signal-archaeologist/examples/basic-example.md
+++ b/skills/signal-archaeologist/examples/basic-example.md
@@ -1,0 +1,17 @@
+# Basic example: signal-archaeologist
+
+## Input
+
+Archive of 850 support tickets from 2024-01 to 2025-12, plus 120 NPS comments.
+
+## Expected output (abbreviated)
+
+**Top slow-burning theme**: "permissions confusion in shared workspaces"
+- 2024 Q1: 4 mentions, sentiment -0.2
+- 2024 Q3: 11 mentions, sentiment -0.4
+- 2025 Q1: 19 mentions, sentiment -0.5
+- 2025 Q3: 31 mentions, sentiment -0.6
+- velocity: +7.2/quarter
+- decay_weighted_importance: 0.83 (rank #1 of 14 themes)
+
+**Buried signal flagged**: "export takes >5 min on accounts >50k rows" — 2 mentions/quarter for 18 months, no team currently owns it.


### PR DESCRIPTION
Adds the `signal-archaeologist` skill — mines historical support tickets, sales call notes, NPS comments, and churned-customer interviews for buried customer signals that surface only over time.

**Layer**: Capture
**Inputs**: archive of historical text artefacts
**Outputs**: signal timeline + decay-corrected theme list

Unique angle: most VoC tools weight all signals equally; this skill applies a recency-decay model and surfaces signals whose *velocity* is changing.