### PR TITLE
feat(jtbd-extractor): port JTBD skill into the library

### DIFF
--- a/skills/jtbd-extractor/README.md
+++ b/skills/jtbd-extractor/README.md
@@ -1,0 +1,8 @@
+# jtbd-extractor
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+Human-readable companion. For the canonical contract, see `SKILL.md`.
+
+## Examples
+- [Basic example](./examples/basic-example.md)

--- a/skills/jtbd-extractor/SKILL.md
+++ b/skills/jtbd-extractor/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: jtbd-extractor
+version: 0.2.0
+description: Extracts functional, emotional, and social Jobs-To-Be-Done from research, with opportunity scoring.
+when_to_use:
+  - You have research data and want to articulate the customer''s underlying job
+  - You are framing a product strategy and need a JTBD list to prioritize against
+  - You want to translate persona pains into actionable jobs
+inputs:
+  - name: research_data
+    type: markdown
+    required: true
+    description: Coded interviews, survey verbatims, or persona cards
+  - name: include_opportunity_scoring
+    type: string
+    required: false
+    description: 'true | false — whether to apply Ulwick opportunity scoring (default true)'
+outputs:
+  - name: jobs
+    type: markdown
+    description: Functional, emotional, and social jobs in canonical JTBD statement form
+  - name: opportunity_scores
+    type: markdown
+    description: Importance × satisfaction-gap scoring per job
+tags: [synthesis, jtbd, opportunity, prioritization]
+maintainer: "@varunk130"
+---
+
+# jtbd-extractor
+
+## Purpose
+
+Convert messy research into canonical JTBD statements: `When [situation], I want to [motivation], so I can [outcome].` Surface functional + emotional + social dimensions, then score opportunity using Ulwick''s importance × satisfaction-gap framework.
+
+## Instructions
+
+1. **Cluster research excerpts** by underlying situation.
+2. **Author functional jobs** in canonical form. Be ruthless about removing solution language.
+3. **For each functional job, surface the emotional and social jobs.** Most JTBD work stops at functional — this is the core mistake.
+4. **Score opportunity** per job:
+   - Importance (1–10): how much does this matter to the customer?
+   - Satisfaction (1–10): how well are existing solutions meeting it?
+   - Opportunity = Importance + max(Importance − Satisfaction, 0)
+   - >12 = high opportunity, 10–12 = medium, <10 = low
+5. **Output ranked job list** with opportunity scores.
+
+## Output format
+
+Two markdown sections: jobs (with all three dimensions) and opportunity scores.
+
+## Limitations
+
+- Opportunity scoring requires importance/satisfaction signal in the research; if missing, the skill estimates from sentiment and flags as low-confidence.
+- Jobs are extracted from the data provided — if the research is biased, so are the jobs.

--- a/skills/jtbd-extractor/examples/basic-example.md
+++ b/skills/jtbd-extractor/examples/basic-example.md
@@ -1,0 +1,13 @@
+# Basic example: jtbd-extractor
+
+## Input
+Coded interviews from 8 fractional CFOs about month-end close.
+
+## Expected output (abbreviated)
+**Functional job**: When closing the books at month-end, I want to reconcile cross-entity transactions in one pass, so I can deliver the close report by Day +5.
+
+**Emotional job**: When the close is in progress, I want to feel in control of the timeline, so I am not the bottleneck for the leadership team.
+
+**Social job**: When presenting the close to the board, I want to project diligence and accuracy, so I am seen as a trusted finance partner.
+
+**Opportunity score**: Importance 9, Satisfaction 4, Opportunity 14 (high).


### PR DESCRIPTION
Ports the `jtbd-extractor` skill from the standalone repo into this library so it composes cleanly with the other discovery skills.

**Layer**: Synthesize
**Note**: The standalone `varunk130/jtbd-extractor` repo remains live for SEO and existing stargazers. This is the canonical version going forward.