### PR TITLE
feat(insight-distiller): synthesize multi-source research with confidence intervals

### DIFF
--- a/skills/insight-distiller/README.md
+++ b/skills/insight-distiller/README.md
@@ -1,0 +1,6 @@
+# insight-distiller
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+## Examples
+- [Basic example](./examples/basic-example.md)

--- a/skills/insight-distiller/SKILL.md
+++ b/skills/insight-distiller/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: insight-distiller
+version: 0.1.0
+description: Synthesizes insights across multiple research sources with confidence intervals and source trails.
+when_to_use:
+  - You have research from 2+ methods (e.g. interviews + surveys + analytics)
+  - You need to publish an insight memo with defensible evidence
+  - You want to know which insights are well-supported vs speculative
+inputs:
+  - name: sources
+    type: json
+    required: true
+    description: 'Array of {type, label, data} — types: interviews, survey, analytics, support, sales'
+  - name: research_question
+    type: string
+    required: true
+    description: The decision the insights need to inform
+outputs:
+  - name: insights
+    type: markdown
+    description: Ranked insights with confidence (L/M/H) and source trail
+  - name: contradictions
+    type: markdown
+    description: Cases where sources disagree, with hypothesis on why
+  - name: gaps
+    type: markdown
+    description: Areas where the research question is unanswered or under-evidenced
+tags: [synthesis, insights, evidence, multi-source]
+maintainer: "@varunk130"
+---
+
+# insight-distiller
+
+## Purpose
+
+Synthesis without evidence trails is opinion. `insight-distiller` enforces that every insight cite its sources, declare its confidence, and explicitly acknowledge gaps and contradictions.
+
+## Instructions
+
+1. **Normalize sources** into a common shape: `{source_id, type, excerpt_or_metric}`.
+2. **Cluster excerpts/metrics into candidate insights.** An insight is a statement that:
+   - Answers (or partially answers) the research question
+   - Is supported by ≥2 source items (ideally from ≥2 source types)
+3. **Score confidence**:
+   - High: ≥3 sources, ≥2 source types, no contradicting evidence
+   - Medium: 2 sources, possibly contradicting evidence with explanation
+   - Low: 1 source, OR contradicting evidence outweighs support
+4. **Build the source trail** for each insight: list the exact source_ids and a 1-line excerpt.
+5. **Surface contradictions** explicitly — these are often more valuable than the insights.
+6. **Identify gaps** — parts of the research question that the data does not address.
+
+## Output format
+
+Three markdown sections: insights (ranked, with confidence + source trail), contradictions, gaps.
+
+## Limitations
+
+- Confidence is a rough heuristic. Quantitative evidence (e.g. a 1000-person survey) deserves more weight than the rules give it.
+- Source trails are only as good as the source labels — invest in good labeling upstream.

--- a/skills/insight-distiller/examples/basic-example.md
+++ b/skills/insight-distiller/examples/basic-example.md
@@ -1,0 +1,12 @@
+# Basic example: insight-distiller
+
+## Input
+10 interviews + 1 NPS survey (n=420) + 6 months of support tickets, on the question: 'Why are mid-market customers churning at month 6?'
+
+## Expected output (abbreviated)
+**Insight (High)**: Mid-market customers hit a complexity wall at month 6 when they outgrow single-team usage and need cross-team admin features that do not exist.
+- Source trail: INT-03, INT-07, INT-09 (quotes), NPS:detractors:cluster-2 (38 verbatims), TICKETS:admin-permission (47 tickets in months 5–7).
+
+**Contradiction (Medium)**: Sales calls suggest pricing is the primary churn driver; tickets and interviews suggest pricing is downstream of the complexity wall. Hypothesis: customers cite price because complexity is harder to articulate.
+
+**Gap**: No data on customers who *did* successfully scale past month 6 — recommend "save" interviews with retained mid-market accounts.


### PR DESCRIPTION
Adds the `insight-distiller` skill — synthesizes insights across multiple research sources (interviews, surveys, support, analytics) with explicit confidence scoring and source-of-evidence trails.

**Layer**: Synthesize
**Unique angle**: every insight is published with its confidence (Low/Medium/High) AND a *source trail* — the specific quotes, data points, and channels that produced it. No more 'because the AI said so.'