### PR TITLE
feat(problem-prism): refract a single problem into 5 reframings

### DIFF
--- a/skills/problem-prism/README.md
+++ b/skills/problem-prism/README.md
@@ -1,0 +1,6 @@
+# problem-prism
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+## Examples
+- [Basic example](./examples/basic-example.md)

--- a/skills/problem-prism/SKILL.md
+++ b/skills/problem-prism/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: problem-prism
+version: 0.1.0
+description: Refracts a single problem statement through 5 lenses (user, business, technical, regulatory, emotional).
+when_to_use:
+  - You suspect your problem framing is too narrow
+  - Your team keeps generating the same kind of solutions
+  - You need to widen the option space before prioritizing
+inputs:
+  - name: problem_statement
+    type: string
+    required: true
+    description: A one-paragraph problem description
+  - name: context
+    type: markdown
+    required: false
+    description: Optional product/market/team context
+outputs:
+  - name: refractions
+    type: markdown
+    description: The same problem reframed through 5 lenses, each with implications
+  - name: highest_leverage_frame
+    type: markdown
+    description: A recommendation for which lens to optimize against, with rationale
+tags: [decide, framing, problem-statement, divergent-thinking]
+maintainer: "@varunk130"
+---
+
+# problem-prism
+
+## Purpose
+
+How-Might-We rewrites change the verb. They do not change the *frame of reference*. `problem-prism` does. The same problem viewed through a regulatory lens vs an emotional lens generates entirely different — and equally valid — solution categories.
+
+## Instructions
+
+1. **Restate the problem** in your own words to confirm understanding. Strip solution language.
+2. **Refract through 5 lenses**, producing one paragraph per lens:
+   - **User lens**: what is the user trying to accomplish, and what is in their way?
+   - **Business lens**: what economic mechanism is broken, and who pays the cost?
+   - **Technical lens**: what system constraint or capability gap is creating this?
+   - **Regulatory / policy lens**: what rule, contract, or norm is implicated?
+   - **Emotional lens**: what feeling is the user trying to avoid or seek?
+3. **For each lens**, list 2–3 implications — what kind of solution becomes plausible.
+4. **Recommend the highest-leverage frame** based on:
+   - Which lens has the largest gap between current and possible state?
+   - Which lens does the team have permission and capability to act on?
+   - Which lens is most under-explored in current strategy?
+
+## Output format
+
+Two markdown sections: refractions (one per lens) and highest-leverage frame (with rationale).
+
+## Limitations
+
+- Lens choice is heuristic; some problems have natural primary lenses (e.g. healthcare → regulatory).
+- Recommends a frame, not a solution. Use with `opportunity-triangulator` next.

--- a/skills/problem-prism/examples/basic-example.md
+++ b/skills/problem-prism/examples/basic-example.md
@@ -1,0 +1,13 @@
+# Basic example: problem-prism
+
+## Input
+Problem: Our free-tier users rarely upgrade to paid, even though usage data shows they would benefit.
+
+## Expected output (abbreviated)
+- **User lens**: They cannot tell which features are paid until they hit a wall mid-task. → onboarding signposting, in-context comparison.
+- **Business lens**: Free tier captures activation cost but not lifetime value. → pricing model change, time-limit free tier.
+- **Technical lens**: Feature gating is binary; no graceful degradation. → metered access, usage-based gating.
+- **Regulatory lens**: ROW pricing differences may be discouraging upgrade in non-USD markets. → pricing localization.
+- **Emotional lens**: Upgrading feels like admitting overuse. → reframe upgrade as "graduating," not "paying more."
+
+**Highest leverage**: Emotional lens — under-explored, costs nothing to test, and the team has full permission. Pair with technical lens (metered access) for compounding effect.


### PR DESCRIPTION
Adds the `problem-prism` skill — takes a single problem statement and refracts it through 5 lenses (user, business, technical, regulatory, emotional). Surfaces the framing that unlocks the best opportunity space.

**Layer**: Decide
**Unique angle**: most problem-framing tools generate How-Might-We rewrites. `problem-prism` instead changes the *frame of reference*, which unlocks completely different solution categories.