### PR TITLE
feat(opportunity-triangulator): size opportunity using 3 independent methods + gap analysis

### DIFF
--- a/skills/opportunity-triangulator/README.md
+++ b/skills/opportunity-triangulator/README.md
@@ -1,0 +1,6 @@
+# opportunity-triangulator
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+## Examples
+- [Basic example](./examples/basic-example.md)

--- a/skills/opportunity-triangulator/SKILL.md
+++ b/skills/opportunity-triangulator/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: opportunity-triangulator
+version: 0.1.0
+description: Sizes opportunity using 3 independent methods (top-down, bottoms-up, value-based) and quantifies the spread.
+when_to_use:
+  - You need to size a new opportunity for a strategy doc or board update
+  - A single TAM number feels too neat and you want intellectual honesty
+  - You are comparing two opportunities and need apples-to-apples sizing
+inputs:
+  - name: opportunity
+    type: string
+    required: true
+    description: One-paragraph description of the opportunity
+  - name: known_inputs
+    type: markdown
+    required: false
+    description: Any existing data — comparable markets, internal usage, pricing, etc.
+outputs:
+  - name: estimates
+    type: markdown
+    description: Three independent estimates with assumptions, math, and sources
+  - name: spread_analysis
+    type: markdown
+    description: Spread between methods, confidence rating, and what would tighten it
+tags: [decide, sizing, tam, opportunity, triangulation]
+maintainer: "@varunk130"
+---
+
+# opportunity-triangulator
+
+## Purpose
+
+A single TAM number is precision theatre. It hides assumptions and overstates confidence. Triangulating with 3 methods and showing the spread is more honest — and frequently changes the decision.
+
+## Instructions
+
+1. **Restate the opportunity** in one paragraph including target buyer, problem, and proposed value exchange.
+2. **Estimate (Method A: top-down)**: industry analyst data → addressable segment → reasonable share. Show every multiplier.
+3. **Estimate (Method B: bottoms-up)**: number of target accounts × average contract value × adoption rate. Show every multiplier.
+4. **Estimate (Method C: value-based)**: per-customer value created (cost saved, revenue added) × number of customers × value-capture rate.
+5. **Compute spread**: ratio of max:min estimate.
+   - <2× → high confidence
+   - 2–5× → medium confidence (typical)
+   - >5× → low confidence — the opportunity is fundamentally uncertain, get more data before betting
+6. **Recommend** which assumptions to validate first to tighten the estimate.
+
+## Output format
+
+Two markdown sections: estimates (three subsections, one per method) and spread analysis (with confidence rating + next-steps).
+
+## Limitations
+
+- Only as good as inputs. Garbage assumptions in, garbage triangulation out.
+- Does not model time-to-revenue or competition.

--- a/skills/opportunity-triangulator/examples/basic-example.md
+++ b/skills/opportunity-triangulator/examples/basic-example.md
@@ -1,0 +1,11 @@
+# Basic example: opportunity-triangulator
+
+## Input
+Opportunity: AI-powered onboarding for mid-market accounting firms.
+
+## Expected output (abbreviated)
+- **Top-down**: 25,000 US mid-market firms × $40k ACV × 5% share = $50M ARR
+- **Bottoms-up**: 18,000 firms with 50–500 employees × $30k ACV × 8% adoption = $43M ARR
+- **Value-based**: 50 hrs saved/firm/yr × $80/hr × 22,000 firms × 25% capture = $22M ARR
+
+**Spread**: 2.3× (medium confidence). Top-down assumes share we have not validated. Validate ACV by piloting with 5 firms before committing.


### PR DESCRIPTION
Adds the `opportunity-triangulator` skill — sizes a market opportunity using 3 independent estimation methods (top-down, bottoms-up, value-based) and surfaces the gap between them as a confidence signal.

**Layer**: Decide
**Unique angle**: most TAM/SAM/SOM exercises produce a single number. This skill produces 3 numbers and treats the *spread* as the headline insight — wide spreads mean low confidence, regardless of how big the average is.