### PR TITLE
feat(hypothesis-stress-tester): adversarially test product hypotheses

### DIFF
--- a/skills/hypothesis-stress-tester/README.md
+++ b/skills/hypothesis-stress-tester/README.md
@@ -1,0 +1,6 @@
+# hypothesis-stress-tester
+
+> See [SKILL.md](./SKILL.md) for the formal specification.
+
+## Examples
+- [Basic example](./examples/basic-example.md)

--- a/skills/hypothesis-stress-tester/SKILL.md
+++ b/skills/hypothesis-stress-tester/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: hypothesis-stress-tester
+version: 0.1.0
+description: Attacks a product hypothesis from 6 adversarial angles and reports survivability.
+when_to_use:
+  - You have a hypothesis you are about to bet engineering quarters on
+  - Your team is too aligned and you suspect groupthink
+  - You need a structured pre-mortem
+inputs:
+  - name: hypothesis
+    type: string
+    required: true
+    description: A specific testable hypothesis ("If we do X, then Y will happen because Z")
+  - name: context
+    type: markdown
+    required: false
+    description: Relevant market, product, and team context
+outputs:
+  - name: attacks
+    type: markdown
+    description: 6 adversarial scenarios, each with severity and likelihood
+  - name: survivability
+    type: markdown
+    description: Overall survivability rating + the strongest attack to address before proceeding
+tags: [decide, hypothesis, adversarial, pre-mortem]
+maintainer: "@varunk130"
+---
+
+# hypothesis-stress-tester
+
+## Purpose
+
+Pre-mortems often degrade into "what could go wrong" brainstorms. This skill runs a structured, adversarial attack across 6 distinct attack surfaces — much harder for the hypothesis to survive all of them.
+
+## Instructions
+
+For the supplied hypothesis, generate one attack per category:
+
+1. **Red-team attack**: a competitor or skeptic argues the hypothesis is false.
+2. **Market-timing attack**: the hypothesis is *true but at the wrong time* (too early / too late).
+3. **Alternative-cause attack**: even if Y happens, it might not be *because of* X (confounding cause).
+4. **Scaling-failure attack**: works at small scale but breaks above N customers / N data points.
+5. **Second-order-effect attack**: succeeding at the hypothesis triggers a worse downstream consequence.
+6. **Ethical / trust attack**: succeeding erodes user trust, brand, or regulatory position.
+
+For each:
+- Score severity (Low/Medium/High)
+- Score likelihood (Low/Medium/High)
+- Suggest one defense or test that would mitigate
+
+Then rate **overall survivability**: Strong / Conditional / Fragile, and name the single strongest attack to address first.
+
+## Output format
+
+Two markdown sections: attacks (6 subsections) and survivability assessment.
+
+## Limitations
+
+- Quality depends on context. Vague hypotheses produce vague attacks — refine the hypothesis first.
+- Some attacks may not apply to all hypotheses; mark as "N/A" rather than forcing.

--- a/skills/hypothesis-stress-tester/examples/basic-example.md
+++ b/skills/hypothesis-stress-tester/examples/basic-example.md
@@ -1,0 +1,11 @@
+# Basic example: hypothesis-stress-tester
+
+## Input
+Hypothesis: If we add an in-app AI assistant to our analytics product, mid-market accounts will increase weekly active users 20%, because they currently struggle with SQL.
+
+## Expected output (abbreviated)
+- **Red-team (High/Medium)**: "Mid-market analysts already use ChatGPT in another tab — your in-app version is redundant and trust-deficient." → Defense: explicit data-context advantage; trust framing.
+- **Alternative-cause (High/High)**: WAU could rise from a launch novelty bump that decays in 60 days, not from durable AI value. → Defense: pre-register success metric as Day-90 retention, not initial WAU.
+- **Second-order (Medium/Medium)**: Success could hide bad SQL skill development in your user base, increasing dependency lock-in (good for retention, bad for trust). → Defense: ship a "show the SQL" mode.
+
+**Survivability: Conditional.** Strongest attack to address first: the alternative-cause (novelty) attack. Re-define success as Day-90 retention before building.


### PR DESCRIPTION
Adds the `hypothesis-stress-tester` skill — takes a product hypothesis (e.g. 'if we build X, mid-market customers will adopt because Y') and runs adversarial scenarios designed to break it.

**Layer**: Decide
**Unique angle**: most hypothesis testing is symmetric (look for evidence for and against). This skill is asymmetric — it explicitly *attacks* the hypothesis from 6 angles (red-team, market-timing, alternative-cause, scaling-failure, second-order-effect, ethical) — and reports survivability.