### PR TITLE
docs: add SUPPORT.md (community support entry point)

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,28 @@
+# Getting help
+
+Thanks for using `ai-customer-discovery-skills`. Here is where to go for help.
+
+## 💬 Questions and ideas
+
+- [GitHub Discussions](https://github.com/varunk130/ai-customer-discovery-skills/discussions) — Q&A, ideas, show-and-tell.
+- For an open-ended question, prefer **Discussions → Q&A** over an issue.
+
+## 🐛 Bug reports
+
+Use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.yml). Include skill name, version, runtime, and steps to reproduce.
+
+## 💡 Feature requests
+
+Use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.yml). Tie the request to a concrete user pain.
+
+## 🆕 Proposing a new skill
+
+Use the [new skill proposal template](.github/ISSUE_TEMPLATE/new_skill_proposal.yml). Include intent, inputs, outputs, and a worked example.
+
+## �� Security issues
+
+See [`SECURITY.md`](SECURITY.md). Do **not** open a public issue for security reports.
+
+## ⏱️ Response expectations
+
+This is a maintainer-led, side-of-desk project. Aim for response within 7 days; merges happen in batches.


### PR DESCRIPTION
Adds SUPPORT.md so contributors and users have a clear, GitHub-recognized place to find support channels. SUPPORT.md surfaces in GitHub's UI as a 'Get help' link.