### PR TITLE
docs: bootstrap README with library overview and install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# AI Customer Discovery Skills
+
+12 AI-powered skills for product discovery — from raw customer signal to validated opportunity. Built for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and [GitHub Copilot](https://github.com/features/copilot).
+
+## Why This Library Exists
+
+Customer discovery is the first place product work goes wrong: signals get cherry-picked, opportunities get sized by gut feel, and personas get over-fitted to whoever shouted loudest in the last interview. This library captures the structured workflows that turn raw signal into evidence — each skill is a self-contained markdown file that any compatible AI agent can load on demand.
+
+## Skills Catalog
+
+_Catalog populated as skills land. See [`skills/`](skills/) for the full list._
+
+## Installation
+
+```bash
+git clone https://github.com/varunk130/ai-customer-discovery-skills.git
+cp -r ai-customer-discovery-skills/skills/* ~/.claude/skills/
+```
+
+Restart Claude Code (or your agent of choice) and invoke skills via slash commands or natural-language prompts.
+
+## License
+
+MIT


### PR DESCRIPTION
Bootstraps the previously-empty repository with a top-level README that frames why the library exists and how to install. Catalog and per-skill links populated by follow-up PRs.