### PR TITLE
docs(readme): add catalog table for the four shipped skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ Customer discovery is the first place product work goes wrong: signals get cherr
 
 ## Skills Catalog
 
-_Catalog populated as skills land. See [`skills/`](skills/) for the full list._
+| Skill | What it does | Use when |
+|-------|--------------|----------|
+| [competitive-analyzer](skills/competitive-analyzer/SKILL.md) | Disciplined competitive teardown that picks the 4–6 buyer-weighted dimensions, scores every competitor, and surfaces gap + risk maps | You need a defensible competitive analysis that changes a decision, not a 40-row feature grid |
+| [north-star-metric-finder](skills/north-star-metric-finder/SKILL.md) | Identifies a candidate North Star Metric using five strict criteria, then maps the input metrics that drive it | You're picking the single metric that will steer two years of roadmap decisions |
+| [feedback-prioritizer](skills/feedback-prioritizer/SKILL.md) | Triages raw customer feedback into a ranked list using the RSCF model, with an explicit `Do Not Act` list for vocal-minority signals | A backlog of tickets / interviews / NPS / sales notes is piling up and the team needs focus |
+| [assumption-mapper](skills/assumption-mapper/SKILL.md) | Surfaces hidden assumptions, classifies them Known / Believed / Hoped × Critical–Low, and outputs a ranked test plan | You're about to commit real investment to a bet and need to know what could kill it first |
 
 ## Installation
 


### PR DESCRIPTION
Replaces the `catalog populated as skills land` placeholder with a real table linking to each shipped SKILL.md so the library is browsable from the entry README.