### PR TITLE
docs(readme): normalize tagline and prose hyphens to em-dashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ flowchart LR
 
 ## Why This Library Exists
 
-Customer discovery is the first place product work goes wrong: signals get cherry-picked, opportunities get sized by gut feel, and personas get over-fitted to whoever shouted loudest in the last interview. This library captures the structured workflows that turn raw signal into evidence - each skill is a self-contained markdown file that any compatible AI agent can load on demand.
+Customer discovery is the first place product work goes wrong: signals get cherry-picked, opportunities get sized by gut feel, and personas get over-fitted to whoever shouted loudest in the last interview. This library captures the structured workflows that turn raw signal into evidence — each skill is a self-contained markdown file that any compatible AI agent can load on demand.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🎯 AI Customer Discovery Skills
 
-### Turn raw customer signal into validated product opportunities - in minutes, not weeks
+### Turn raw customer signal into validated product opportunities — in minutes, not weeks
 
 [![Skills](https://img.shields.io/badge/Shipped_Skills-4-blue?style=for-the-badge)](#-skills-catalog)
 [![Roadmap](https://img.shields.io/badge/Target-12_skills-orange?style=for-the-badge)](#-roadmap)


### PR DESCRIPTION
## Summary

The tagline and the "Why This Library Exists" paragraph used hyphen-with-spaces ( `-` ) where the rest of the portfolio uses em-dashes ( `—` ). Bring this README in line.

## Changes (2 commits)

1. `docs(readme): use em-dash in tagline to match portfolio style`
2. `docs(readme): use em-dash in 'turn raw signal into evidence' sentence`